### PR TITLE
Strict Mode must always be enabled in the first line of code

### DIFF
--- a/02-Fundamentals-Part-2/starter/script.js
+++ b/02-Fundamentals-Part-2/starter/script.js
@@ -1,0 +1,11 @@
+"use strict";
+
+console.log("⭐️⭐️⭐️⭐️⭐️⭐️ Start of Script.js script ⭐️⭐️⭐️⭐️⭐️");
+
+// **** Tutorial 32 - Strict Mode
+// In the below example, "hasDriverLicence" is missing the "s" letter - strict mode will highlight this in the console and show us that there is a spelling inconsistency, whereas without strict mode, the code will execute
+let hasDriversLicense = false;
+const passTest = true;
+
+if (passTest) hasDriverLicense = true;
+if (hasDriversLicense) console.log("I can drive 🙂");


### PR DESCRIPTION
Strict Mode must always be enabled in the first line of code

In the below example, "hasDriverLicence" is missing the "s" letter - strict mode will highlight this in the console and show us that there is a spelling inconsistency, whereas without strict mode, the code will execute

let hasDriversLicense = false;
const passTest = true;

if (passTest) hasDriverLicense = true;
if (hasDriversLicense) console.log("I can drive 🙂");